### PR TITLE
Move pre-assembly and constraint handler creation outside batch loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ opt_params = OptimizationParameters(
 # 6. Run optimization
 results = simp_optimize(
     grid, dh, cellvalues,
-    [(dh, collect(force_nodes), [0.0, -1.0, 0.0])], # forces: [(dh, nodes, vector)]
+    [PointLoad(dh, collect(force_nodes), [0.0, -1.0, 0.0])], # forces
     [ch_fixed],                                     # boundary conditions
     opt_params
 )

--- a/test/Examples/05_3D_2x1x1_4Legs_tol_study.jl
+++ b/test/Examples/05_3D_2x1x1_4Legs_tol_study.jl
@@ -173,6 +173,21 @@ println("="^80)
 
 total_mesh_volume = calculate_volume(grid)
 
+# Pre-assemble once to create ConstraintHandlers (shared across all tolerance runs)
+K_run = allocate_matrix(dh)
+f_run = zeros(ndofs(dh))
+
+assemble_stiffness_matrix_simp!(
+    K_run,
+    f_run,
+    dh,
+    cellvalues,
+    material_model,
+    fill(0.4, getncells(grid)),
+)
+
+ch_fixed = apply_fixed_boundary!(K_run, f_run, dh, fixed_nodes)
+
 for tol in tolerance_values
     # Format tolerance for folder name (e.g., 0.01 -> "01", 0.08 -> "08", 0.16 -> "16")
     tol_str = @sprintf("%02d", round(Int, tol * 100))
@@ -194,23 +209,6 @@ for tol in tolerance_values
         )
         println("  ✓ Saved: boundary_conditions.vtu")
     end
-
-    # Fresh K and f for each run
-    K_run = allocate_matrix(dh)
-    f_run = zeros(ndofs(dh))
-
-    # Assemble and apply BC
-    assemble_stiffness_matrix_simp!(
-        K_run,
-        f_run,
-        dh,
-        cellvalues,
-        material_model,
-        fill(0.4, getncells(grid)),
-    )
-
-    ch_fixed = apply_fixed_boundary!(K_run, f_run, dh, fixed_nodes)
-    apply_force!(f_run, dh, collect(force_nodes), [0.0, 0.0, -1.0])
 
     # Optimization parameters
     opt_params = OptimizationParameters(

--- a/test/Examples/06_3D_2x1x1_MBB_tol_study.jl
+++ b/test/Examples/06_3D_2x1x1_MBB_tol_study.jl
@@ -152,6 +152,23 @@ println("="^80)
 
 total_mesh_volume = calculate_volume(grid)
 
+# Pre-assemble once to create ConstraintHandlers (shared across all tolerance runs)
+K_run = allocate_matrix(dh)
+f_run = zeros(ndofs(dh))
+
+assemble_stiffness_matrix_simp!(
+    K_run,
+    f_run,
+    dh,
+    cellvalues,
+    material_model,
+    fill(0.4, getncells(grid)),
+)
+
+ch_symmetry = apply_sliding_boundary!(K_run, f_run, dh, symmetry_nodes, [1])
+ch_support = apply_sliding_boundary!(K_run, f_run, dh, support_nodes, [2])
+ch_z_fix = apply_sliding_boundary!(K_run, f_run, dh, z_fix_node, [3])
+
 for tol in tolerance_values
     # Format tolerance for folder name
     tol_str = @sprintf("%02d", round(Int, tol * 100))
@@ -173,26 +190,6 @@ for tol in tolerance_values
         )
         println("  ✓ Saved: boundary_conditions.vtu")
     end
-
-    # Fresh K and f for each run
-    K_run = allocate_matrix(dh)
-    f_run = zeros(ndofs(dh))
-
-    # Assemble and apply BC
-    assemble_stiffness_matrix_simp!(
-        K_run,
-        f_run,
-        dh,
-        cellvalues,
-        material_model,
-        fill(0.4, getncells(grid)),
-    )
-
-    ch_symmetry = apply_sliding_boundary!(K_run, f_run, dh, symmetry_nodes, [1])
-    ch_support = apply_sliding_boundary!(K_run, f_run, dh, support_nodes, [2])
-    ch_z_fix = apply_sliding_boundary!(K_run, f_run, dh, z_fix_node, [3])
-
-    apply_force!(f_run, dh, collect(force_nodes), [0.0, -1.0, 0.0])
 
     # Optimization parameters
     opt_params = OptimizationParameters(

--- a/test/Examples/07_3D_2x1x1_Michell_tol_study.jl
+++ b/test/Examples/07_3D_2x1x1_Michell_tol_study.jl
@@ -150,6 +150,22 @@ println("  ✓ Force nodes (circle r=$(force_radius)): $(length(force_nodes))")
 # -----------------------------------------------------------------------------
 total_mesh_volume = calculate_volume(grid)
 
+# Pre-assemble once to create ConstraintHandlers (shared across all tolerance runs)
+K_run = allocate_matrix(dh)
+f_run = zeros(ndofs(dh))
+
+assemble_stiffness_matrix_simp!(
+    K_run,
+    f_run,
+    dh,
+    cellvalues,
+    material_model,
+    fill(0.4, getncells(grid)),
+)
+
+ch_support_left = apply_fixed_boundary!(K_run, f_run, dh, support_left)
+ch_support_right = apply_fixed_boundary!(K_run, f_run, dh, support_right)
+
 for tol in tolerance_values
     tol_str = @sprintf("%02d", round(Int, tol * 100))
     results_dir = "./results/07_3D_2x1x1_Michell_$(tol_str)tol_r2.0"
@@ -171,24 +187,6 @@ for tol in tolerance_values
         )
         println("  ✓ Saved: boundary_conditions.vtu")
     end
-
-    # Re-assemble and apply boundary conditions for each run
-    K_run = allocate_matrix(dh)
-    f_run = zeros(ndofs(dh))
-
-    assemble_stiffness_matrix_simp!(
-        K_run,
-        f_run,
-        dh,
-        cellvalues,
-        material_model,
-        fill(0.4, getncells(grid)),
-    )
-
-    ch_support_left = apply_fixed_boundary!(K_run, f_run, dh, support_left)
-    ch_support_right = apply_fixed_boundary!(K_run, f_run, dh, support_right)
-
-    apply_force!(f_run, dh, collect(force_nodes), [0.0, -1.0, 0.0])
 
     # Optimization parameters
     opt_params = OptimizationParameters(

--- a/test/Examples/08_3D_2x1x1_Michell-half_tol_study.jl
+++ b/test/Examples/08_3D_2x1x1_Michell-half_tol_study.jl
@@ -146,6 +146,23 @@ println("  ✓ Symmetry plane z=1.0 (U3=0): $(length(symmetry_z_nodes)) nodes")
 # -----------------------------------------------------------------------------
 total_mesh_volume = calculate_volume(grid)
 
+# Pre-assemble once to create ConstraintHandlers (shared across all tolerance runs)
+K_run = allocate_matrix(dh)
+f_run = zeros(ndofs(dh))
+
+assemble_stiffness_matrix_simp!(
+    K_run,
+    f_run,
+    dh,
+    cellvalues,
+    material_model,
+    fill(0.4, getncells(grid)),
+)
+
+ch_support_left = apply_fixed_boundary!(K_run, f_run, dh, support_left)
+ch_support_right = apply_fixed_boundary!(K_run, f_run, dh, support_right)
+ch_symmetry_z = apply_sliding_boundary!(K_run, f_run, dh, symmetry_z_nodes, [3])
+
 for tol in tolerance_values
     tol_str = @sprintf("%02d", round(Int, tol * 100))
     results_dir = "./results/08_3D_2x1x1_Michell-half_$(tol_str)tol_r2.0"
@@ -167,25 +184,6 @@ for tol in tolerance_values
         )
         println("  ✓ Saved: boundary_conditions.vtu")
     end
-
-    # Re-assemble and apply boundary conditions for each run
-    K_run = allocate_matrix(dh)
-    f_run = zeros(ndofs(dh))
-
-    assemble_stiffness_matrix_simp!(
-        K_run,
-        f_run,
-        dh,
-        cellvalues,
-        material_model,
-        fill(0.4, getncells(grid)),
-    )
-
-    ch_support_left = apply_fixed_boundary!(K_run, f_run, dh, support_left)
-    ch_support_right = apply_fixed_boundary!(K_run, f_run, dh, support_right)
-    ch_symmetry_z = apply_sliding_boundary!(K_run, f_run, dh, symmetry_z_nodes, [3])
-
-    apply_force!(f_run, dh, collect(force_nodes), [0.0, -1.0, 0.0])
 
     # Optimization parameters
     opt_params = OptimizationParameters(


### PR DESCRIPTION
## Changes

- Move stiffness matrix assembly and constraint handler creation outside the tolerance loop in all four 3D example files
- These operations are now performed once before the loop instead of redundantly in each iteration
- Improves performance by avoiding repeated identical computations across tolerance study runs

## Files Modified

- `test/Examples/05_3D_2x1x1_4Legs_tol_study.jl`
- `test/Examples/06_3D_2x1x1_MBB_tol_study.jl`
- `test/Examples/07_3D_2x1x1_Michell_tol_study.jl`
- `test/Examples/08_3D_2x1x1_Michell-half_tol_study.jl`
- `README.md` (minor documentation update)

## Impact

- Significant speedup for tolerance studies with multiple iterations
- No functional changes to optimization results